### PR TITLE
Fix: Prevent crash from race condition in logging handler

### DIFF
--- a/stockstui/log_handler.py
+++ b/stockstui/log_handler.py
@@ -38,12 +38,17 @@ class TextualHandler(logging.Handler):
             # FIX: Always use call_from_thread. This is the canonical way to
             # schedule a callback on the main event loop thread from any thread,
             # including the main one. It ensures thread-safety without complex checks.
-            self.app.call_from_thread(
-                self.app.notify,
-                message,
-                title=record.levelname.capitalize(),
-                severity=severity,
-                timeout=8
-            )
+            try:
+                self.app.call_from_thread(
+                    self.app.notify,
+                    message,
+                    title=record.levelname.capitalize(),
+                    severity=severity,
+                    timeout=8
+                )
+            except RuntimeError:
+                # This can happen if a worker thread tries to log a message
+                # after the app has already shut down. It's safe to ignore.
+                pass
         except Exception:
             self.handleError(record)


### PR DESCRIPTION
This commit fixes a race condition that could occur during application shutdown.

If a background worker thread tried to log a message after the main Textual application had already shut down, it would raise a `RuntimeError: App is not running`, causing an unhandled exception to be printed to the console.

The `emit` method in the `TextualHandler` class now wraps the call to `app.call_from_thread` in a `try...except RuntimeError` block. This allows the handler to gracefully ignore log messages that arrive after the app has terminated, preventing the crash and cleaning up the shutdown process.